### PR TITLE
Subframe by subframe sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ struct mlsp_config streamer_config= {NULL, 9766, 500}; //listen on any, port, 50
 streamer=mlsp_init_server(&streamer_config);
 
 //here we will be getting data
-mlsp_frame *streamer_frame;
+const mlsp_frame *streamer_frame;
 
 while(keep_working)
 {

--- a/README.md
+++ b/README.md
@@ -52,15 +52,10 @@ while(keep_working)
 	//prepare your data in some way
 	//...
 
-	//each sent frame should be identified with increasing frame number
-	network_frame.framenumber = your_framenumber;
+	network_frame.data = your_data_pointer;
+	network_frame.size = your_data_size;
 
-	//MLSP frame may carry multiple logical subframes
-	//typically only single subframe is used (index 0)
-	network_frame.data[0] = your_data_pointer;
-	network_frame.size[0] = your_data_size;
-
-	mlsp_send(streamer, &frame)
+	mlsp_send(streamer, &frame, 0);
 }
 
 mlsp_close(streamer);
@@ -100,6 +95,11 @@ while(keep_working)
 
 mlsp_close(streamer);
 ```
+
+The same interface with minor changes works for multi-frame streaming:
+- pass number of subframes in `mlsp_config`
+- use `mlsp_send(m, &frame, 0)`, `mlsp_send(m, &frame, 1)`, ...
+- `mlsp_receive` returns array of subframe size
 
 ## Library uses
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ mlsp_close(streamer);
 
 The same interface with minor changes works for multi-frame streaming:
 - pass number of subframes in `mlsp_config`
+- `mlsp_receive` returns array of subframes size
 - use `mlsp_send(m, &frame, 0)`, `mlsp_send(m, &frame, 1)`, ...
-- `mlsp_receive` returns array of subframe size
 
 ## Library uses
 

--- a/mlsp.c
+++ b/mlsp.c
@@ -195,16 +195,7 @@ static struct mlsp *mlsp_close_and_return_null(struct mlsp *m)
 	return NULL;
 }
 
-int mlsp_send(struct mlsp *m, const struct mlsp_frame *frame)
-{
-	for(int i = 0;i<m->subframes;++i)
-		if( mlsp_send_subframe(m, &frame[i], i) != MLSP_OK )
-			return MLSP_ERROR;
-
-	return MLSP_OK;
-}
-
-int mlsp_send_subframe(struct mlsp *m, const struct mlsp_frame *frame, uint8_t subframe)
+int mlsp_send(struct mlsp *m, const struct mlsp_frame *frame, uint8_t subframe)
 {
 	const uint8_t *data = frame->data;
 	const uint32_t data_size = frame->size;

--- a/mlsp.c
+++ b/mlsp.c
@@ -294,9 +294,13 @@ struct mlsp_frame *mlsp_receive(struct mlsp *m, int *error)
 		{
 			m->received_subframes[udp.subframe] = 1;
 
+			int received = 0;
+
 			for(int i=0;i<udp.subframes;++i)
-				if(!m->received_subframes[i])
-					continue;
+				received += m->received_subframes[i];
+
+			if(received != udp.subframes)
+				continue;
 			
 			mlsp_decode_payload(m, &udp, &m->frame);
 			

--- a/mlsp.c
+++ b/mlsp.c
@@ -280,7 +280,7 @@ struct mlsp_frame *mlsp_receive(struct mlsp *m, int *error)
 
 		if(collected->received_packets[udp.packet])
 		{
-			fprintf(stderr, "mlsp: ignoring packeet (duplicate)\n");
+			fprintf(stderr, "mlsp: ignoring packet (duplicate)\n");
 			continue;
 		}
 
@@ -321,6 +321,8 @@ static int mlsp_decode_header(struct mlsp *m, int size, struct mlsp_packet *udp)
 	udp->subframe = data[3];
 	memcpy(&udp->packets, data+4, sizeof(udp->packets));
 	memcpy(&udp->packet, data+6, sizeof(udp->packet));
+
+	udp->size = size - PACKET_HEADER_SIZE;
 	
 	if(udp->size > PACKET_MAX_PAYLOAD)
 	{

--- a/mlsp.c
+++ b/mlsp.c
@@ -346,7 +346,7 @@ static int mlsp_decode_header(struct mlsp *m, int size, struct mlsp_packet *udp)
 		return MLSP_ERROR;
 	}
 	
-	if(udp->subframes >= m->subframes || udp->subframe >= m->subframes)
+	if(udp->subframes > m->subframes || udp->subframe >= m->subframes)
 	{
 		fprintf(stderr, "mlsp: ignoring packet with incorrect subframe(s)\n");
 		return MLSP_ERROR;

--- a/mlsp.h
+++ b/mlsp.h
@@ -30,6 +30,7 @@ struct mlsp_config
 	const char *ip; //!< IP (send to or listen on) or NULL and "\0" for server (listen on any)
 	uint16_t port; //!< port to listen on (server) or send to (client)
 	int timeout_ms; //!< 0 or positive number of ms
+	int subframes; //!< number of logical subframes carried by single frame, 0 is treated as 1
 };
 
 enum mlsp_retval_enum

--- a/mlsp.h
+++ b/mlsp.h
@@ -51,8 +51,7 @@ struct mlsp *mlsp_init_client(const struct mlsp_config *config);
 struct mlsp *mlsp_init_server(const struct mlsp_config *config);
 void mlsp_close(struct mlsp *m);
 
-int mlsp_send(struct mlsp *m, const struct mlsp_frame *frame);
-int mlsp_send_subframe(struct mlsp *m, const struct mlsp_frame *frame, uint8_t subframe);
+int mlsp_send(struct mlsp *m, const struct mlsp_frame *frame, uint8_t subframe);
 
 //non NULL on success, NULL on failure or timeout
 //the ownership of mlsp_packet remains with library

--- a/mlsp.h
+++ b/mlsp.h
@@ -43,9 +43,8 @@ enum mlsp_retval_enum
 //user level logical frame to send
 struct mlsp_frame
 {
-	uint16_t framenumber;
-	uint8_t *data[MLSP_MAX_SUBFRAMES];
-	uint32_t size[MLSP_MAX_SUBFRAMES];
+	const uint8_t *data;
+	uint32_t size;
 };
 
 struct mlsp *mlsp_init_client(const struct mlsp_config *config);
@@ -53,10 +52,11 @@ struct mlsp *mlsp_init_server(const struct mlsp_config *config);
 void mlsp_close(struct mlsp *m);
 
 int mlsp_send(struct mlsp *m, const struct mlsp_frame *frame);
+int mlsp_send_subframe(struct mlsp *m, const struct mlsp_frame *frame, uint8_t subframe);
 
 //non NULL on success, NULL on failure or timeout
 //the ownership of mlsp_packet remains with library
-struct mlsp_frame *mlsp_receive(struct mlsp *m, int *error);
+const struct mlsp_frame *mlsp_receive(struct mlsp *m, int *error);
 void mlsp_receive_reset(struct mlsp *m);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Rework library (protocol, interface) to allow sending logical subframes independently.

This allows optimizing:
- bandwidth (better use over time)
- latency (e.g. first subframe sent while second encoded)

Related to #12